### PR TITLE
Rewrite kthread-based operations with CMWQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ On module insertion, you can pass following parameters to the module:
     Port you want the module to listen. If the default port is in use, or you simply want to use another port, you can use this param to specify.
   - backlog (`128` by default)
 
-    Backlog amount you want the module to use. Typically, you only need to change this if you encounter too much concurrent connections warning, which will be logged in the kernel message like this, `Possible SYN flooding on port 12345`. For details about SYN flooding, you can refer to the [SYN flood wiki](https://en.wikipedia.org/wiki/SYN_flood). Changing this param allows the kernel to handle more/less connections concurrently.
+    Backlog amount you want the module to use. Typically, you only need to change this if you encounter warning of too much concurrent connections, which will be logged in the kernel message like this, `Possible SYN flooding on port 12345`.  For details about SYN flooding, you can refer to the [SYN flood wiki](https://en.wikipedia.org/wiki/SYN_flood). Changing this param allows the kernel to handle more/less connections concurrently.
+  - bench (`0` by default)
+  
+    By setting this param to `1`, you gain better cache locality during benchmarking the module. More specifically, we use [`WQ_UNBOUND`](https://www.kernel.org/doc/html/latest/core-api/workqueue.html#flags) as workqueue (hereafter called "wq") creation flag for the module by default, because this flag allows you to establish both long term (use telnet-like program to interact with the module) and short term (benchmarking) connection to the module. However, this flag has a trade-off, which is cache locality. The origin of this trade-off is that tasks submitted to a unbounded wq are executed by arbitrary CPU core. Therefore, you can set the param to `1` to disable `WQ_UNBOUND` flag. By disabling this flag, tasks submitted to the CMWQ are actually submitted to a wq named system wq, which is a wq shared by the whole system. Tasks in the system wq are executed by the CPU core who submitted the task at most of the time. **BE AWARE** that if you use telnet-like program to interact with the module with the param set to `1`, your machine may get unstable since your connection may stalls other tasks in the system wq. For details about the CMWQ, you can refer to the [documentation](https://www.kernel.org/doc/html/latest/core-api/workqueue.html).
 ```
-$ sudo insmod fastecho.ko port=<port_you_want> backlog=<amount_you_want>
+$ sudo insmod fastecho.ko port=<port_you_want> backlog=<amount_you_want> bench=<either_1_or_0>
 ```
 
 After the module is loaded, you can use `telnet` to interact with the module:

--- a/echo_server.h
+++ b/echo_server.h
@@ -1,12 +1,25 @@
 #ifndef ECHO_SERVER_H
 #define ECHO_SERVER_H
 
+#include <linux/module.h>
+#include <linux/workqueue.h>
 #include <net/sock.h>
 
 #define MODULE_NAME "fastecho"
 
 struct echo_server_param {
     struct socket *listen_sock;
+};
+
+struct echo_service {
+    bool is_stopped;
+    struct list_head worker;
+};
+
+struct fastecho {
+    struct socket *sock;
+    struct list_head list;
+    struct work_struct fastecho_work;
 };
 
 extern int echo_server_daemon(void *);

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CPPCHECK_OPTS="-I. -I./include --error-exitcode=1 ."
+CPPCHECK_OPTS="--inline-suppr -I. -I./include --error-exitcode=1 ."
 
 RETURN=0
 CLANG_FORMAT=$(which clang-format)


### PR DESCRIPTION
Workqueue is an asynchronous execution mechanism that has an ubiquitous presence in the Linux Kernel. It is used for various purposes from simple context bouncing to hosting a persistent in-kernel service thread.

In this pull request, we shall first discuss several performance issues that are enhanced by the Concurrency Managed Workqueue(CMWQ). We will then look at kecho execution scenario which will illustrate how CMWQ serves as a robust async mechanism without introducing any noticeable performance degradation. This will be followed by an overview of the CMWQ API and its design.

The CMWQ impl has merely the same behavior to kthread-ver daemon, except that when a connection is still alive at removal of the module, kthread-ver daemon will simply proceed with the module removal, but crash the machine once that any of existing connections being closed, whereas CMWQ-ver will simply closes all connections.

The impl has been tested on Ubuntu 18.04 (kernel: v5.3.0).

Following is the performance comparison of kthread-daemon and CMWQ-daemon, thanks to locality of CMWQ-worker and its ready-to-use worker pool, the performance has at least x10 improvement on CMWQ-daemon:

CMWQ-based:
![cmwq](https://user-images.githubusercontent.com/19415202/75097104-b3288080-55e1-11ea-8649-02e169779a3b.png)

kthread-based:
![kthread_bench](https://user-images.githubusercontent.com/19415202/75097111-cb000480-55e1-11ea-8a33-80e990239152.png)

Finally, thanks @afcidk for pointing out my mis-reuse of a pointer.