### PR TITLE
Adjust TCP backlog of user-echo-server

### DIFF
--- a/user-echo-server.c
+++ b/user-echo-server.c
@@ -139,7 +139,21 @@ int main(void)
         server_err("Fail to bind", &list);
     printf("Listener was binded to %s\n", inet_ntoa(addr.sin_addr));
 
-    if (listen(listener, 1) < 0)
+    /*
+     * the backlog, which is "128" here, is also the default attribute of
+     * "/proc/sys/net/core/somaxconn" before Linux 5.4.
+     * 
+     * specifying the backlog greater than "somaxconn" will be truncated
+     * to the maximum attribute of "somaxconn" silently. But you can also
+     * adjust "somaxconn" by using command:
+     * 
+     * $ sudo sysctl net.core.somaxconn=<value>
+     * 
+     * For details, please refer to:
+     * 
+     * http://man7.org/linux/man-pages/man2/listen.2.html
+     */
+    if (listen(listener, 128) < 0)
         server_err("Fail to listen", &list);
 
     int epoll_fd;


### PR DESCRIPTION
In current impl, TCP backlog of the listener socket is 1, this
will cause some of requests get timeout error since backlog of
1 throttles the throughput of the server.

As [listen(2)](http://man7.org/linux/man-pages/man2/listen.2.html) stated:
```
If the backlog argument is greater than the value in
/proc/sys/net/core/somaxconn, then it is silently truncated to
that value.  Since Linux 5.4, the default in this file is 4096;
in earlier kernels, the default value is 128.
```

Consider Linux 5.4 hasn't spreads to stable version of various
distros, I think using 128 as the backlog is appropriate.