### PR TITLE
Eliminate Cppcheck warnings

### DIFF
--- a/echo_server.c
+++ b/echo_server.c
@@ -116,8 +116,8 @@ static struct work_struct *create_work(struct socket *sk)
 /* it would be better if we do this dynamically */
 static void free_work(void)
 {
-    struct kecho *l, *tar;
-    /* cppcheck-suppress uninitvar */
+    struct kecho *tar;
+    struct kecho *l;
 
     list_for_each_entry_safe (tar, l, &daemon.worker, list) {
         kernel_sock_shutdown(tar->sock, SHUT_RDWR);


### PR DESCRIPTION
`--inline-suppr` in `scripts/pre-commit.hook` was removed since e06a72e7, this makes C files with single-line-multi-declarations but without init value fail to pass static analysis.

Consider `--inline-suppr` has been removed, I split the declaration into two lines, which prevents the warning.