### PR TITLE
Re-add cppcheck inline suppression flag

### DIFF
--- a/echo_server.c
+++ b/echo_server.c
@@ -116,8 +116,8 @@ static struct work_struct *create_work(struct socket *sk)
 /* it would be better if we do this dynamically */
 static void free_work(void)
 {
-    struct kecho *tar;
-    struct kecho *l;
+    struct kecho *l, *tar;
+    /* cppcheck-suppress uninitvar */
 
     list_for_each_entry_safe (tar, l, &daemon.worker, list) {
         kernel_sock_shutdown(tar->sock, SHUT_RDWR);

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 CPPCHECK_suppresses="--suppress=missingIncludeSystem \
-		     --suppress=knownConditionTrueFalse:drop-tcp-socket.c"
+                     --suppress=knownConditionTrueFalse:drop-tcp-socket.c \
+                     --inline-suppr"
 CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses ."
 
 RETURN=0


### PR DESCRIPTION
Suppress static analysis warnings.

Fixes #5.