### PR TITLE
Perform static check on git-tracked files

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -3,7 +3,7 @@
 CPPCHECK_suppresses="--suppress=missingInclude \
                      --suppress=knownConditionTrueFalse:drop-tcp-socket.c \
                      --inline-suppr"
-CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses ."
+CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses"
 
 RETURN=0
 CLANG_FORMAT=$(which clang-format)
@@ -75,7 +75,9 @@ do
 done
 
 # static analysis
-$CPPCHECK $CPPCHECK_OPTS >/dev/null
+git ls-tree --full-tree -r --name-only HEAD | \
+    grep -v compat | grep -E "\.(c|cc|cpp|h|hh|hpp)\$" | \
+    xargs $CPPCHECK $CPPCHECK_OPTS >/dev/null
 if [ $? -ne 0 ]; then
     RETURN=1
     echo "" >&2


### PR DESCRIPTION
Use git object to specify the files that need to be checked.