### PR TITLE
Fix build with Linux v5.17+

### DIFF
--- a/drop-tcp-socket.c
+++ b/drop-tcp-socket.c
@@ -12,6 +12,10 @@
 #define HAVE_PROC_OPS
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 17, 0)
+#define PDE_DATA pde_data
+#endif
+
 #include <net/netns/generic.h>
 #include <net/tcp.h>
 


### PR DESCRIPTION
PDE_DATA() has been renamed to pde_data() since Linux v5.17.

This commit adds a Linux version check and define PDE_DATA as an alias of pde_data to make it compatible with Linux v5.17+.