### PR TITLE
Reject module insertion after kthread_run fail

### DIFF
--- a/kecho_mod.c
+++ b/kecho_mod.c
@@ -73,6 +73,7 @@ static int kecho_init_module(void)
     if (IS_ERR(echo_server)) {
         printk(KERN_ERR MODULE_NAME ": cannot start server daemon\n");
         close_listen(listen_sock);
+        return PTR_ERR(echo_server);
     }
 
     return 0;


### PR DESCRIPTION
In the original module init function, if the `kthread_run` fails, the `IS_ERR(echo_server)` will be `true`，and the socket will be release. However, it will not return error, so that the kernel module will be successfully inserted into the kernel. 
```cpp
if (IS_ERR(echo_server)) {
    printk(KERN_ERR MODULE_NAME ": cannot start server daemon\n");
    close_listen(listen_sock);
}

return 0;
```
Since it is hard to make the `kthread_run` fail, I test it with directly assigning `ERR_PTR(-NOMEM)` to `echo_server` to simulate the out-of-memory situation.
```diff
-echo_server = kthread_run(echo_server_daemon, &param, MODULE_NAME);
+echo_server = ERR_PTR(-ENOMEM);
```
After inserting the kernel module, using `dmesg` command, the following message is shown:
```
[441907.721201] kecho: cannot start server daemon
```
However, using `lsmod` command, we can still see that this kernel module is successfully inserted:
```
kecho                  12288  0
```
Furthermore, while removing the module, the NULL pointer dereference is shown:
```
[441941.383358] BUG: kernel NULL pointer dereference, address: 0000000000000c3c
```

This change adds the following code to return the error code:
```diff
+return PTR_ERR(echo_server);
```
Then, when error happens, the `insmod` will fail as expected:
```
insmod: ERROR: could not insert module kecho.ko: Cannot allocate memory
```